### PR TITLE
Allow multiple errors

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -137,8 +137,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 		return errors.Wrap(err, "decoding response")
 	}
 	if len(gr.Errors) > 0 {
-		// return first error
-		return gr.Errors[0]
+		return gr.bundleErrors()
 	}
 	return nil
 }
@@ -204,8 +203,7 @@ func (c *Client) runWithPostFields(ctx context.Context, req *Request, resp inter
 		return errors.Wrap(err, "decoding response")
 	}
 	if len(gr.Errors) > 0 {
-		// return first error
-		return gr.Errors[0]
+		return gr.bundleErrors()
 	}
 	return nil
 }
@@ -242,6 +240,19 @@ func (e graphErr) Error() string {
 type graphResponse struct {
 	Data   interface{}
 	Errors []graphErr
+}
+
+func (resp graphResponse) bundleErrors() error {
+	var err error
+
+	for _, graphqlError := range resp.Errors {
+		if err != nil {
+			err = errors.Wrap(err, graphqlError.Message)
+		} else {
+			err = errors.New(graphqlError.Message)
+		}
+	}
+	return err
 }
 
 // Request is a GraphQL request.

--- a/graphql_multipart_test.go
+++ b/graphql_multipart_test.go
@@ -72,9 +72,10 @@ func TestDoErr(t *testing.T) {
 		query := r.FormValue("query")
 		is.Equal(query, `query {}`)
 		io.WriteString(w, `{
-			"errors": [{
-				"message": "Something went wrong"
-			}]
+			"errors": [
+			{ "message": "Something went wrong" },
+			{ "message": "Something else went wrong" }
+			]
 		}`)
 	}))
 	defer srv.Close()
@@ -87,7 +88,7 @@ func TestDoErr(t *testing.T) {
 	var responseData map[string]interface{}
 	err := client.Run(ctx, &Request{q: "query {}"}, &responseData)
 	is.True(err != nil)
-	is.Equal(err.Error(), "graphql: Something went wrong")
+	is.Equal(err.Error(), "Something else went wrong: Something went wrong")
 }
 
 func TestDoNoResponse(t *testing.T) {


### PR DESCRIPTION
Instead of just returning the first error, wrap them up.